### PR TITLE
Исправлена работа программы в режиме демона на UNIX-системах

### DIFF
--- a/NetCoreConsoleApplication/Program.cs
+++ b/NetCoreConsoleApplication/Program.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Linq;
+using System.Threading;
 
 namespace ZidiumServerMonitor
 {
@@ -8,9 +10,19 @@ namespace ZidiumServerMonitor
         {
             var application = new Application();
             application.Start();
-            Console.WriteLine("Press any key to stop...");
-            Console.ReadKey();
-            application.Stop();
+
+            bool runAsService = args.Any(x => string.Compare("--service", x, StringComparison.OrdinalIgnoreCase) == 0);
+
+            if (runAsService)
+            {
+                Thread.Sleep(Timeout.Infinite);
+            }
+            else
+            {
+                Console.WriteLine("Press any key to stop...");
+                Console.ReadKey();
+                application.Stop();
+            }
         }
     }
 }


### PR DESCRIPTION
При работе консольного приложения в режиме демона (например, через systemd) возникает ```InvalidOperationException``` в ```Console.ReadKey``` из-за отсутствия консоли.  ```Environment.UserInteractive``` всегда возвращает ```true```, поэтому пришлось сделать так.

В идеале надо будет посмотреть, как делать кроссплатформенные приложения, которые могут работать как службы, в .NET Core, думаю, должен быть какой-то пакет...