### PR TITLE
Доработки в задаче производительности дисков для Linux

### DIFF
--- a/Core/Services/DiskPerformance/DiskPerformanceServiceLinux.cs
+++ b/Core/Services/DiskPerformance/DiskPerformanceServiceLinux.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Text.Json;
@@ -53,6 +54,9 @@ namespace ZidiumServerMonitor
             using var process = Process.Start(processStartInfo);
             using StreamReader streamReader = process.StandardOutput;
             process.WaitForExit();
+
+            if (process.ExitCode != 0)
+                throw new Exception($"Command \"{cmd} {args}\" returned a non-zero exit code ({process.ExitCode}).");
 
             return streamReader.ReadToEnd().Trim();
         }

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Server Monitor - это приложение, написанное на .Net 6, 
 
 В параметре Tasks/DiskPerformanceTask/Disks укажите названия дисков, для которых вы хотите собирать данные производительности.
 Для Windows это названия счётчиков производительности, например "0 C:", их можно получить, выполнив в powershell команду `Get-WmiObject -Query "select Name from win32_perfformatteddata_perfdisk_physicaldisk"`.
-Для Linux это названия дисков, например "sda", их можно получить командой lsblk, столбец NAME.
+Для Linux это названия дисков, например "sda", их можно получить командой `lsblk`, столбец NAME. Также можно использовать уникальные ID дисков, выводимые командой `iostat -j id`, столбец Device. Если в ответ на эту команду выводится "Invalid type of persistent device name", то данная функция не поддерживается.
 
 Пример файла appsettings.Production.json:
 ```


### PR DESCRIPTION
1. Поддерживаем уникальные имена дисков согласно схеме в `/dev/disk/by-id/`
2. Проверяем код выхода `iostat` , чтобы не показывать простыню в логе при ошибке десериализации JSON в момент завершения процесса